### PR TITLE
Allow parent to intercept touch event when scrolling to the edge

### DIFF
--- a/zoomage/src/main/java/com/jsibbold/zoomage/ZoomageView.java
+++ b/zoomage/src/main/java/com/jsibbold/zoomage/ZoomageView.java
@@ -527,7 +527,8 @@ public class ZoomageView extends AppCompatImageView implements OnScaleGestureLis
     }
 
     protected boolean disallowParentTouch(MotionEvent event) {
-        if ((currentPointerCount > 1 || currentScaleFactor > 1.0f || isAnimating())) {
+        boolean isTranslatedToEdge = restrictBounds && isScrollToEdge();
+        if (currentPointerCount > 1 || (currentScaleFactor > 1.0f && !isTranslatedToEdge) || isAnimating()) {
             return true;
         } else {
             return false;
@@ -544,6 +545,11 @@ public class ZoomageView extends AppCompatImageView implements OnScaleGestureLis
 
     private boolean isAnimating() {
         return resetAnimator != null && resetAnimator.isRunning();
+    }
+
+    private boolean isScrollToEdge() {
+        return bounds.left == 0.0 || bounds.right == getWidth()
+                || bounds.top == 0.0 || bounds.bottom == getHeight();
     }
 
     /**


### PR DESCRIPTION
This PR allows parent to intercept touch event when scrolling to the edge.

**Issue**
In viewpager, when image got zoomed, could not move to next/previous image by swiping 
